### PR TITLE
Fix ValueError when file has timestamp older than 1980

### DIFF
--- a/cbr2cbz.py
+++ b/cbr2cbz.py
@@ -428,7 +428,7 @@ def cbr2cbz(
     if verbose>1:
         print ("** Creating with zipfile: {0}, mode '{1}'".format(outfile,zipmode))
     try:
-        outzip=zipfile.ZipFile(outfile,mode=zipmode,compression=zipfile.ZIP_STORED)
+        outzip=zipfile.ZipFile(outfile,mode=zipmode,compression=zipfile.ZIP_STORED,strict_timestamps=False)
 
     except FileExistsError:
         # This really shouldn't happen, tested in main() and earlier


### PR DESCRIPTION
I tracked down an issue where occasionally the try/except on line 462 would fail with exception "ValueError".

Adding some exception logging resulted in this message:

`ValueError: ZIP does not support timestamps before 1980`

I found in the zipfile module you can provide option `strict_timestamps=False` to disable the file date strictness.  When disabling this feature, the file date will get changed to the minimum supported by the module, and not produce an exception.

That's what I've added and suggest you consider merging this change to prevent others suffering this issue.